### PR TITLE
qdl: Add support for UFS3.1 parameters

### DIFF
--- a/firehose.c
+++ b/firehose.c
@@ -486,6 +486,11 @@ int firehose_apply_ufs_common(struct qdl_device *ctx, struct ufs_common *ufs) {
     xml_set_property_format(node_to_send, "bConfigDescrLock", "%d",
                             0/*ufs->bConfigDescrLock*/); //Safety, remove before fly
 
+    xml_set_property_format(node_to_send, "bWriteBoosterBufferPreserveUserSpaceEn", "%d",
+                            ufs->bWriteBoosterBufferPreserveUserSpaceEn);
+    xml_set_property_format(node_to_send, "bWriteBoosterBufferType", "%d", ufs->bWriteBoosterBufferType);
+    xml_set_property_format(node_to_send, "shared_wb_buffer_size_in_qb", "%d", ufs->shared_wb_buffer_size_in_kb);
+
     ret = firehose_send_single_tag(ctx, node_to_send);
     if (ret)
         fprintf(stderr, "[APPLY UFS common] %d\n", ret);

--- a/ufs.c
+++ b/ufs.c
@@ -74,6 +74,10 @@ struct ufs_common *ufs_parse_common_params(xmlNode *node, bool finalize_provisio
     result->bInitActiveICCLevel = attr_as_unsigned(node, "bInitActiveICCLevel", &errors);
     result->wPeriodicRTCUpdate = attr_as_unsigned(node, "wPeriodicRTCUpdate", &errors);
     result->bConfigDescrLock = attr_as_unsigned(node, "bConfigDescrLock", &errors) != 0;
+    result->bWriteBoosterBufferPreserveUserSpaceEn =
+            attr_as_unsigned(node, "bWriteBoosterBufferPreserveUserSpaceEn", &errors) != 0;
+    result->bWriteBoosterBufferType = attr_as_unsigned(node, "bWriteBoosterBufferType", &errors);
+    result->shared_wb_buffer_size_in_kb = attr_as_unsigned(node, "shared_wb_buffer_size_in_kb", &errors);
 
     if (errors) {
         fprintf(stderr, "[UFS] errors while parsing common\n");

--- a/ufs.h
+++ b/ufs.h
@@ -43,6 +43,9 @@ struct ufs_common {
     unsigned bInitActiveICCLevel;
     unsigned wPeriodicRTCUpdate;
     bool bConfigDescrLock;
+    bool bWriteBoosterBufferPreserveUserSpaceEn;
+    unsigned bWriteBoosterBufferType;
+    unsigned shared_wb_buffer_size_in_kb;
 };
 
 struct ufs_body {


### PR DESCRIPTION
WriteBooster is a mandatory feature on UFS 3.1 and required for provisioning. Add the XML fields for the firehose.