### PR TITLE
qdl: Allow user to decide USB OUT buffer multiplier

### DIFF
--- a/README
+++ b/README
@@ -14,3 +14,30 @@ and libraries, found in e.g. the libxml2-dev and libudev-dev packages
 
 With these installed run:
   make
+
+
+Buffer multiplier
+========
+**Warning**
+Using this parameter might not work stable on your system. Read [760b3df](https://github.com/andersson/qdl/commit/760b3dffb03d2b7dfb82c6eac652a092f51c572d) for
+more details.
+
+
+To improve flashing speed buffer multiplier parameter was added.
+It uses bigger buffers for sending data on USB what allows to flash
+faster.
+
+Measurements made on VM Linux Mint 21.1 and may vary compared to native
+machine.
+
+| Multiplier | Measured speed [kB/s] |
+| ---------- | --------------------- |
+| 1          | 3365                  |
+| 2          | 6219                  |
+| 4          | 11515                 |
+| 8          | 18058                 |
+| 16         | 25133                 |
+| 32         | 28872                 |
+| 64         | 33399                 |
+| 128        | 36208                 |
+| 256        | 35574                 |

--- a/qdl.h
+++ b/qdl.h
@@ -18,6 +18,8 @@ struct qdl_device {
     __attribute__((unused)) size_t in_max_pkt_size;
     size_t out_max_pkt_size;
 
+    size_t multiplier;
+
     char *mappings[MAPPING_SZ]; // array index is the id from the device
 };
 


### PR DESCRIPTION
- Due to issue related in 760b3df qdl is not sending big chunk of data at once to USB driver. That affects performance of flashing. This change allows user to set multiplier of buffer size. If may cause issues on some machines but gives huge speed gain.